### PR TITLE
Add expert assignment feature to orders

### DIFF
--- a/server/app/Http/Controllers/Dashboard/OrderController.php
+++ b/server/app/Http/Controllers/Dashboard/OrderController.php
@@ -6,6 +6,7 @@ use App\Enums\LogsTypes;
 
 use App\Http\Controllers\Controller;
 use App\Models\Order;
+use App\Models\User;
 use App\Traits\HelperTrait;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -15,7 +16,9 @@ class OrderController extends Controller
     use HelperTrait;
     public function index(){
         $order = Order::with('customer' , 'employee' , 'address' , 'payment')->get();
-        return view('admin.Order.index' , compact('order'));
+        $experts = User::whereHas('roles', fn($q) => $q->where('name', 'Expert'))->pluck('first_name', 'id');
+
+        return view('admin.Order.index' , compact('order', 'experts'));
     }
 
     public function updateStatus(Request $request, Order $order){
@@ -34,5 +37,18 @@ class OrderController extends Controller
     public function show(Order $order){
         $order = Order::with('customer', 'employee', 'address', 'payment', 'orderDetails.product')->findOrFail($order->id);
         return view('admin.Order.show' , compact('order'));
+    }
+
+    public function assign(Request $request, Order $order)
+    {
+        $request->validate([
+            'expert_id' => 'required|exists:users,id',
+        ]);
+
+        $order->update(['expert_id' => $request->expert_id, 'employee_id' => auth()->user()->id]);
+
+        $this->logAction(auth()->id(), 'assign_service_request', 'Service request assigned: Service Request ID ' . $order->id . ' to Expert ID: ' . $request->expert_id, LogsTypes::INFO->value);
+        return redirect()->route('dashboard.service-request.index')
+        ->with('success', 'Expert assigned successfully.');
     }
 }

--- a/server/app/Http/Controllers/Dashboard/ProductController.php
+++ b/server/app/Http/Controllers/Dashboard/ProductController.php
@@ -111,10 +111,20 @@ class ProductController extends Controller
 
     public function show($product)
     {
-        $product = Product::with(['shops' => function ($query) {
-            $query->take(3);
-        }, 'categories'])->findOrFail($product);
-        return view('admin.Product.show', compact('product'));
+       $product = Product::with([
+            'reviews' => function ($query) {
+                $query->select('id', 'product_id', 'rating');
+            },
+            'shops' => function ($query) {
+                $query->take(3);
+            },
+            'categories'
+        ])
+        ->withCount('reviews')
+        ->findOrFail($product);
+
+        $ratingSum = $product->reviews->sum('rating');
+        return view('admin.Product.show', compact('product', 'ratingSum'));
     }
 
     public function delete(DeleteProductRequest $request, $id)

--- a/server/app/Models/Order.php
+++ b/server/app/Models/Order.php
@@ -15,6 +15,7 @@ class Order extends Model
         'total_price',
         'customer_id',// store the user_id
         'employee_id',
+        'assigned_to',
         'coupon_id',
         'payment_id',
         'status',
@@ -58,5 +59,9 @@ class Order extends Model
     }
     public function orderDetails(){
         return $this->hasMany(OrderDetail::class, 'order_id', 'id');
+    }
+    public function expert()
+    {
+        return $this->belongsTo(User::class, 'assigned_to');
     }
 }

--- a/server/database/migrations/2025_06_02_095458_add_assigned_to_column_to_orders_table.php
+++ b/server/database/migrations/2025_06_02_095458_add_assigned_to_column_to_orders_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->string('assigned_to')->after('status')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('assigned_to');
+        });
+    }
+};

--- a/server/resources/views/admin/Order/index.blade.php
+++ b/server/resources/views/admin/Order/index.blade.php
@@ -7,7 +7,7 @@
     <x-management-table
         title="Order Management"
         :headers="[
-            '#', 'Customer Name', 'Managed By', 'Recipient Name', 'Recipient Phone', 'Status', 'Payment Info', 'Address', 'Actions'
+            '#', 'Customer Name', 'Managed By', 'Recipient Name', 'Recipient Phone', 'Assigned To', 'Status', 'Payment Info', 'Address', 'Actions'
         ]"
         :items="$order"
         :Route="'dashboard.order'"
@@ -23,6 +23,21 @@
                     </td>
                     <td>{{ $record->first_name ?? 'N/A' }} {{ $record->last_name ?? '' }}</td>
                     <td>{{ $record->phone_number ?? 'N/A' }}</td>
+                    <td>
+                        @if ($record->expert)
+                            {{ $record->expert->first_name }} {{ $record->expert->last_name }}
+                        @else
+                            <form method="POST" action="{{ route($Route . '.assign', $record->id) }}">
+                                @csrf
+                                <select name="expert_id" onchange="this.form.submit()" class="form-select">
+                                    <option value="">Select Expert</option>
+                                    @foreach($experts as $id => $name)
+                                        <option value="{{ $id }}">{{ $name }}</option>
+                                    @endforeach
+                                </select>
+                            </form>
+                        @endif
+                    </td>
                     <td>
                         <form action="{{ route($Route . '.updateStatus', $record->id) }}" method="POST">
                             @csrf

--- a/server/resources/views/admin/Product/show.blade.php
+++ b/server/resources/views/admin/Product/show.blade.php
@@ -114,6 +114,10 @@
                                             <h5 class="text-muted font-weight-semibold mb-2">Sold Quantity</h5>
                                             <p class="text-dark mb-0">{{ $product->sold_quantity ?? 0 }}</p>
                                         </div>
+                                        <div class="col-12 col-sm-6 mb-4">
+                                            <h5 class="text-muted font-weight-semibold mb-2">Rating</h5>
+                                            <p class="text-dark mb-0">{{ $ratingSum ?? 0 }}</p>
+                                        </div>
                                         <div class="col-12 mb-4">
                                             <h5 class="text-muted font-weight-semibold mb-2">Categories</h5>
                                             <p class="text-dark">

--- a/server/resources/views/admin/ServiceRequest/index.blade.php
+++ b/server/resources/views/admin/ServiceRequest/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <x-management-table
         title="Service Request Management"
-        :headers="['#', 'Customer Name', 'Service Name', 'Assign To Expert','Status', 'Managed By Employee','Address', 'Action']"
+        :headers="['#', 'Customer Name', 'Service Name', 'Assigned To','Status', 'Managed By Employee','Address', 'Action']"
         :items="$serviceRequests"
         :Route="'dashboard.service-request'"
     >

--- a/server/routes/dashboard.php
+++ b/server/routes/dashboard.php
@@ -141,6 +141,9 @@ Route::name('dashboard.')->middleware('web')->prefix('dashboard')->group(functio
 
         Route::name('order')->prefix('order')->group(function () {
             Route::get('/', [OrderController::class, 'index'])->name('');
+             Route::post('{order}/assign', [OrderController::class, 'assign'])
+                ->name('.assign')
+                ->whereNumber('order');
             Route::get('/{order}', [OrderController::class, 'show'])->name('.show');
             Route::put('/{order}', [OrderController::class, 'updateStatus'])->name('.updateStatus');
         });


### PR DESCRIPTION
- Introduced 'assigned_to' column in orders table via migration.
- Updated OrderController to handle expert assignment and retrieve experts.
- Modified order index view to display assigned expert and allow assignment.
- Enhanced product show view to display rating sum.
- Adjusted service request index view to reflect changes in headers.